### PR TITLE
Transfer Owner Template

### DIFF
--- a/src/improvements/tasks/MultisigTask.sol
+++ b/src/improvements/tasks/MultisigTask.sol
@@ -149,12 +149,7 @@ abstract contract MultisigTask is Test, Script, ITask {
     /// For nested multisig, prints the data to sign and the hash to approve for each of the child multisigs.
     /// @param taskConfigFilePath The path to the task configuration file.
     function simulateRun(string memory taskConfigFilePath) public override {
-        /// child multisig is set to value passed from the signFromChildMultisig function
-
-        /// sets safe to the safe set in addresses.json
         _taskSetup(taskConfigFilePath);
-        /// now we override it to what is set in config.toml, which is a child multisig,
-        /// then, call _setIsNestedSafe(), which flips the flag from true to false <-- this is where our error is
 
         /// now execute task actions
         build();
@@ -392,6 +387,7 @@ abstract contract MultisigTask is Test, Script, ITask {
 
         signatures = Signatures.prepareSignatures(multisig, hash, signatures);
 
+        vm.broadcast();
         (bool success) = IGnosisSafe(multisig).execTransaction(
             MULTICALL3_ADDRESS,
             0,

--- a/src/improvements/template/TransferOwnerTemplate.sol
+++ b/src/improvements/template/TransferOwnerTemplate.sol
@@ -1,0 +1,56 @@
+pragma solidity 0.8.15;
+
+import {SystemConfig} from "@eth-optimism-bedrock/src/L1/SystemConfig.sol";
+import {ProxyAdmin} from "@eth-optimism-bedrock/src/universal/ProxyAdmin.sol";
+
+import {MultisigTask} from "src/improvements/tasks/MultisigTask.sol";
+import {AddressRegistry as Addresses} from "src/improvements/AddressRegistry.sol";
+
+/// @title TransferOwnerTemplate
+/// @notice Template contract for transferring ownership of the proxy admin
+contract TransferOwnerTemplate is MultisigTask {
+    /// @notice new owner address
+    address public newOwner;
+
+    /// @notice Returns the safe address string identifier
+    /// @return The string "SystemConfigOwner"
+    function safeAddressString() public pure override returns (string memory) {
+        return "SystemConfigOwner";
+    }
+
+    /// @notice Returns the storage write permissions required for this task
+    /// @return Array of storage write permissions, in this case, only the ProxyAdmin is returned
+    function _taskStorageWrites() internal pure virtual override returns (string[] memory) {
+        string[] memory storageWrites = new string[](1);
+        storageWrites[0] = "ProxyAdmin";
+        return storageWrites;
+    }
+
+    /// @notice Sets up the template with the new owner from a TOML file
+    /// @param taskConfigFilePath Path to the TOML configuration file
+    function _templateSetup(string memory taskConfigFilePath) internal override {
+        newOwner = abi.decode(vm.parseToml(vm.readFile(taskConfigFilePath), ".newOwner"), (address));
+        /// only allow one chain to be modified at a time with this template
+        Addresses.ChainInfo[] memory _chains =
+            abi.decode(vm.parseToml(vm.readFile(taskConfigFilePath), ".l2chains"), (Addresses.ChainInfo[]));
+        require(_chains.length == 1, "Must specify exactly one chain id to transfer ownership for");
+    }
+
+    /// @notice Builds the actions for setting gas limits for a specific L2 chain ID
+    /// @param chainId The ID of the L2 chain to configure
+    function _build(uint256 chainId) internal override {
+        /// View only, filtered out by MultisigTask.sol
+        ProxyAdmin proxyAdmin = ProxyAdmin(addresses.getAddress("ProxyAdmin", chainId));
+
+        /// Mutative call, recorded by MultisigTask.sol for generating multisig calldata
+        proxyAdmin.transferOwnership(newOwner);
+    }
+
+    /// @notice Validates that gas limits were set correctly for the specified chain ID
+    /// @param chainId The ID of the L2 chain to validate
+    function _validate(uint256 chainId) internal view override {
+        ProxyAdmin proxyAdmin = ProxyAdmin(addresses.getAddress("ProxyAdmin", chainId));
+
+        assertEq(proxyAdmin.owner(), newOwner, "new owner not set correctly");
+    }
+}

--- a/test/tasks/mock/example/task-05/config.toml
+++ b/test/tasks/mock/example/task-05/config.toml
@@ -1,0 +1,7 @@
+# this is the file used to determine the network configuration
+
+l2chains = [{name = "OP Devnet", chainId = 20022002}]
+
+templateName = "TransferOwnerTemplate"
+
+newOwner = "0x5cd0D260AF719ed8Ec66dfaf23d338d534EDbb4F"


### PR DESCRIPTION
Template to transfer ownership of proxy admin from one multisig to another.

first checkout the superchain registry to the correct commit hash so it has our testnet config loaded.

```
cd lib/superchain-registry/
git pull
git checkout bm/superchain-ops-improvements-testnet
```

commands to generate signatures:

```
cd test/tasks/mock/example/task-05

OWNER_SAFE='' SCRIPT_NAME=TransferOwnerTemplate ETH_RPC_URL="https://ethereum-sepolia-rpc.publicnode.com" just --justfile ../../../../../src/improvements/single.just sign <ledger_account_index>
```

signature:

```
Data: 0x1901bf8e35a84085f28a7cb97bf95d2b1d3fcb9605cd26f8bbb1138ad84ec4b116b8605a14b6fa538cb98571ae0aefba6315a20bbed15a292e7ee554e69c3bd09a50
Signer: 0xF5BE490707e5d97B42FbE0C5801573718adD98d3
Signature: 23585bc74e7f8ea67d0c4008b6957be44d7bb00a8b5bae1c31646476a92bac0a6c14a76be493e5fd02df0c9817f3ceaafa560ca5bb292468d46737b7d8527e7c1c
```

Tenderly output:

https://dashboard.tenderly.co/elliotfriedman/solidity-labs/simulator/1ecd393c-b181-43bf-b53e-4d3e2ea2a4b9/state-diff